### PR TITLE
Added first_name and last_name to user schema through migration & updated users seeds

### DIFF
--- a/db/migrate/20240123235654_add_first_name_to_users.rb
+++ b/db/migrate/20240123235654_add_first_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddFirstNameToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :first_name, :string
+  end
+end

--- a/db/migrate/20240123235935_add_last_name_to_users.rb
+++ b/db/migrate/20240123235935_add_last_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastNameToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_20_092251) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_23_235935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_20_092251) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,16 +15,19 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_20_092251) do
   enable_extension "plpgsql"
 
   create_table "bookings", force: :cascade do |t|
-    t.date "start_date"
-    t.date "end_date"
-    t.boolean "status"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.integer "status", default: 0
     t.text "comment"
     t.bigint "user_id", null: false
     t.bigint "service_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["end_date"], name: "index_bookings_on_end_date"
     t.index ["service_id"], name: "index_bookings_on_service_id"
+    t.index ["start_date"], name: "index_bookings_on_start_date"
     t.index ["user_id"], name: "index_bookings_on_user_id"
+    t.check_constraint "start_date < end_date", name: "start_date_before_end_date"
   end
 
   create_table "services", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,10 +12,12 @@ Booking.destroy_all
 puts 'Creating 5 new users'
 5.times do
   user = User.create!(
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
     email: Faker::Internet.email,
     password: 'password'
   )
-  puts "#{user.email} has been created"
+  puts "#{user.first_name} has been created"
 end
 puts "Users are done!"
 


### PR DESCRIPTION
We originally defined users to have a "name" on our DB schema:
![image](https://github.com/HappyDay101/Friends-4-Benefits/assets/135202658/2cd0c929-86bc-4157-9ea7-93e1b1d0962b)

But I noticed that "first_name" and "last_name" was used in a definition within the user model:
![image](https://github.com/HappyDay101/Friends-4-Benefits/assets/135202658/9ff93935-6245-43db-81b2-f15aaf13d139)

So I ran migrations to add both "first_name" and "last_name" to our user table schema:
![image](https://github.com/HappyDay101/Friends-4-Benefits/assets/135202658/34e1723b-608e-43fd-92a1-9fd08ed91be2)

And updated our user seeds with new "first_names" and "last_names" through faker:
![image](https://github.com/HappyDay101/Friends-4-Benefits/assets/135202658/3b691e9f-9c14-4cce-bd34-a82b954c2f44)
